### PR TITLE
makes cards on contact page mobile view 1 column stacked instead of 2 columns

### DIFF
--- a/src/app/contato/page.tsx
+++ b/src/app/contato/page.tsx
@@ -40,7 +40,7 @@ export default function ContactsRoot() {
 
       <Divider />
 
-      <div className="text-center grid grid-cols-2 gap-0.5 overflow-hidden sm:mx-0 sm:rounded-2xl md:grid-cols-3">
+      <div className="text-center grid grid-cols-1 sm:grid-cols-2 gap-0.5 overflow-hidden sm:mx-0 sm:rounded-2xl md:grid-cols-3">
         {contacts.map((contact, index) => (
           <div className="bg-blue-600/5 p-8 sm:p-10" key={`contact-${index}`}>
             <span className="inline-block">


### PR DESCRIPTION
This PR intends to fix layout of Contact Page on mobile view.

While testing the page on iPhone 15 Pro Max, I've noticed that the contacts cards on the Contact Page were bleeding into one another. This was due to their content being too large for a 2-column layout.

This PR makes those cards use 1-column stacked layout on mobile view.